### PR TITLE
migrate to Pin Fast lib functions

### DIFF
--- a/firmware/OneWire.h
+++ b/firmware/OneWire.h
@@ -14,8 +14,6 @@
 #define ONEWIRE_CRC 1
 #endif
 
-
-
 // You can allow 16-bit CRC checks by defining this to 1
 // (Note that ONEWIRE_CRC must also be 1.)
 #ifndef ONEWIRE_CRC16
@@ -31,97 +29,6 @@ class OneWire
 private:
   uint16_t _pin;
 
-/**************Conditional fast pin access for Core and Photon*****************/
-  #if PLATFORM_ID == 0 // Core
-    inline void digitalWriteFastLow() {
-      PIN_MAP[_pin].gpio_peripheral->BRR = PIN_MAP[_pin].gpio_pin;
-    }
-
-    inline void digitalWriteFastHigh() {
-      PIN_MAP[_pin].gpio_peripheral->BSRR = PIN_MAP[_pin].gpio_pin;
-    }
-
-    inline void pinModeFastOutput() {
-      GPIO_TypeDef *gpio_port = PIN_MAP[_pin].gpio_peripheral;
-      uint16_t gpio_pin = PIN_MAP[_pin].gpio_pin;
-
-      GPIO_InitTypeDef GPIO_InitStructure;
-
-      if (gpio_port == GPIOA )
-      {
-        RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE);
-      }
-      else if (gpio_port == GPIOB )
-      {
-        RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOB, ENABLE);
-      }
-
-      GPIO_InitStructure.GPIO_Pin = gpio_pin;
-      GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_PP;
-      GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
-      PIN_MAP[_pin].pin_mode = OUTPUT;
-      GPIO_Init(gpio_port, &GPIO_InitStructure);
-    }
-
-    inline void pinModeFastInput() {
-      GPIO_TypeDef *gpio_port = PIN_MAP[_pin].gpio_peripheral;
-      uint16_t gpio_pin = PIN_MAP[_pin].gpio_pin;
-
-      GPIO_InitTypeDef GPIO_InitStructure;
-
-      if (gpio_port == GPIOA )
-      {
-        RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE);
-      }
-      else if (gpio_port == GPIOB )
-      {
-        RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOB, ENABLE);
-      }
-
-      GPIO_InitStructure.GPIO_Pin = gpio_pin;
-      GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN_FLOATING;
-      PIN_MAP[_pin].pin_mode = INPUT;
-      GPIO_Init(gpio_port, &GPIO_InitStructure);
-    }
-
-    inline uint8_t digitalReadFast() {
-      return GPIO_ReadInputDataBit(PIN_MAP[_pin].gpio_peripheral, PIN_MAP[_pin].gpio_pin);
-    }
-
-  //#elif PLATFORM_ID == 6 || PLATFORM_ID == 8 || PLATFORM_ID == 10 // Photon(P0),P1,Electron
-  #else // just do this for everything else until they change it again
-    STM32_Pin_Info* PIN_MAP = HAL_Pin_Map(); // Pointer required for highest access speed
-
-    inline void digitalWriteFastLow() {
-      PIN_MAP[_pin].gpio_peripheral->BSRRH = PIN_MAP[_pin].gpio_pin;
-    }
-
-    inline void digitalWriteFastHigh() {
-      PIN_MAP[_pin].gpio_peripheral->BSRRL = PIN_MAP[_pin].gpio_pin;
-    }
-
-    inline void pinModeFastOutput(void){
-      // This could probably be speed up by digging a little deeper past
-      // the HAL_Pin_Mode function.
-      HAL_Pin_Mode(_pin, OUTPUT);
-    }
-
-    inline void pinModeFastInput(void){
-      // This could probably be speed up by digging a little deeper past
-      // the HAL_Pin_Mode function.
-      HAL_Pin_Mode(_pin, INPUT);
-    }
-
-    inline uint8_t digitalReadFast(void){
-      // This could probably be speed up by digging a little deeper past
-      // the HAL_GPIO_Read function.
-      return HAL_GPIO_Read(_pin);
-    }
-
-  //#else  // no need for this right now
-    //#error "*** PLATFORM_ID not supported by this library. PLATFORM should be Core, Photon, P1 or Electron ***"
-  #endif
-/**************End conditional fast pin access for Core and Photon*************/
 
 #if ONEWIRE_SEARCH
     // global search state


### PR DESCRIPTION
I already started this so thought I would throw what I have done to you.  The Pin_Fast lib matches 100% to your previous work.  I matched function for function and moved HAL_Pin_Mode calls to reside inside the functions, which I see now does strip the inline, not sure what the impact would be.  Anyways, hopefully this will give you a little boost and help.

From fast_pin.h:

``` cpp
#elif defined(STM32F2XX)
static STM32_Pin_Info* PIN_MAP = HAL_Pin_Map();

inline void pinSetFast(pin_t _pin) __attribute__((always_inline));
inline void pinResetFast(pin_t _pin) __attribute__((always_inline));
inline int32_t pinReadFast(pin_t _pin) __attribute__((always_inline));

inline void pinSetFast(pin_t _pin)
{
    PIN_MAP[_pin].gpio_peripheral->BSRRL = PIN_MAP[_pin].gpio_pin;
}

inline void pinResetFast(pin_t _pin)
{
    PIN_MAP[_pin].gpio_peripheral->BSRRH = PIN_MAP[_pin].gpio_pin;
}

inline int32_t pinReadFast(pin_t _pin)
{
    return ((PIN_MAP[_pin].gpio_peripheral->IDR & PIN_MAP[_pin].gpio_pin) == 0 ? LOW : HIGH);
}
```
